### PR TITLE
Fix X-XSS-Protection missing semicolon

### DIFF
--- a/2.3/nginx.conf
+++ b/2.3/nginx.conf
@@ -66,7 +66,7 @@ http {
   # It's usually enabled by default anyway, so the role of this header is to re-enable the filter for
   # this particular website if it was disabled by the user.
   # https://www.owasp.org/index.php/List_of_useful_HTTP_headers
-  add_header X-XSS-Protection "1; mode=block";
+  add_header X-XSS-Protection "1; mode=block;";
 
   # config to enable HSTS(HTTP Strict Transport Security) https://developer.mozilla.org/en-US/docs/Security/HTTP_Strict_Transport_Security
   # to avoid ssl stripping https://en.wikipedia.org/wiki/SSL_stripping#SSL_stripping
@@ -77,7 +77,7 @@ http {
   # you can tell the browser that it can only download content from the domains you explicitly allow
   # http://www.html5rocks.com/en/tutorials/security/content-security-policy/
   # https://www.owasp.org/index.php/Content_Security_Policy
-  # add_header Content-Security-Policy: "default-src 'none'; script-src 'self' 'unsafe-eval' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; connect-src 'self'; img-src 'self' data: https://*.s3.amazonaws.com blob:";
+  # add_header Content-Security-Policy "default-src 'none'; script-src 'self' 'unsafe-eval' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; connect-src 'self'; img-src 'self' data: https://*.s3.amazonaws.com blob:";
 
   ##
   # Virtual Host Configs


### PR DESCRIPTION
Browsers report an error of a missing semicolon in `X-XSS-Protection` header.

@alachaum @ouranos Please validate and merge