### PR TITLE
Add logging + Improve retrieval of archive file name

### DIFF
--- a/2.3/docker-entrypoint.sh
+++ b/2.3/docker-entrypoint.sh
@@ -20,15 +20,18 @@ fi
 
 # Clone app from git
 if [ -n "$GIT_URL" ] && [ -n "$GIT_BRANCH" ]; then
+  echo "Retrieving code for branch: $GIT_BRANCH"
   [ -d /app/.git ] || git clone --branch "$GIT_BRANCH" --depth 50 $GIT_URL /app
   [ -n "$GIT_COMMIT_ID" ] && git checkout -qf $GIT_COMMIT_ID
+  echo $(git log -1 HEAD --pretty)
 # Download app from S3
 elif [ -n "$S3_URI" ]; then
   if [ -z "$S3_SECRET_ACCESS_KEY" ]; then
     opts="--no-sign-request"
   fi
   AWS_ACCESS_KEY_ID=$S3_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY=$S3_SECRET_ACCESS_KEY AWS_DEFAULT_REGION=$S3_REGION aws s3 cp $opts $S3_URI ./
-  archive_file=$(ls)
+  archive_file=${S3_URI##*/}
+  echo "Unzipping $archive_file"
   tar xf $archive_file
   rm -f $archive_file
 fi


### PR DESCRIPTION
If someday there is already a file in /app, `archive_file=$(ls)` will stop working.
`archive_file=${S3_URI##*/}` is a more robust way to retrieve the filename.