### PR TITLE
Upgrade mysql-client (5.7+)

### DIFF
--- a/2.3/Dockerfile
+++ b/2.3/Dockerfile
@@ -1,12 +1,27 @@
 FROM ruby:2.3
 
+ENV MYSQL_APT_VERSION 0.8.9-1
+ENV DEBIAN_FRONTEND noninteractive
+
 # Install System libraries
-RUN apt-get update && apt-get install -y \
+RUN apt-get update \
+  && apt-get upgrade -y \
+  && apt-get install -y \
     git \
     imagemagick \
     nginx \
     supervisor \
     awscli \
+    lsb-release \
+    debconf-utils
+
+# Use official MySQL repository
+RUN wget http://dev.mysql.com/get/mysql-apt-config_${MYSQL_APT_VERSION}_all.deb
+RUN echo "mysql-apt-config mysql-apt-config/select-tools select Enabled" | debconf-set-selections
+RUN dpkg -i mysql-apt-config_${MYSQL_APT_VERSION}_all.deb \
+  && rm -f mysql-apt-config_${MYSQL_APT_VERSION}_all.deb \
+  && apt-get update \
+  && apt-get install -y libmysqlclient-dev \
   && rm -rf /var/lib/apt/lists/*
 
 # gpg keys listed at https://github.com/nodejs/node#release-team


### PR DESCRIPTION
Upgrade mysql client to benefit from seamless connection upgrade when the actual mysql server support TLS.