### PR TITLE
Bump node version

### DIFF
--- a/2.3/Dockerfile
+++ b/2.3/Dockerfile
@@ -27,7 +27,7 @@ RUN set -ex \
   done
 
 ENV NPM_CONFIG_LOGLEVEL info
-ENV NODE_VERSION 6.12.0
+ENV NODE_VERSION 6.14.4
 
 RUN curl -SLO "https://nodejs.org/dist/v$NODE_VERSION/node-v$NODE_VERSION-linux-x64.tar.xz" \
   && curl -SLO "https://nodejs.org/dist/v$NODE_VERSION/SHASUMS256.txt.asc" \


### PR DESCRIPTION
Bump node version as it's required by the mnoe build.

Still locked on an old version of node by impac-angular dependencies

@adamaziz15 FYI