### PR TITLE
Add ruby 2.4 & 2.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ services:
   - docker
 
 env:
+  - VERSION=2.6
   - VERSION=2.5
   - VERSION=2.3
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ services:
 env:
   - VERSION=2.6
   - VERSION=2.5
+  - VERSION=2.4
   - VERSION=2.3
 
 before_install:

--- a/2.3/Dockerfile
+++ b/2.3/Dockerfile
@@ -12,19 +12,21 @@ RUN apt-get update && apt-get install -y \
 # gpg keys listed at https://github.com/nodejs/node#release-team
 RUN set -ex \
   && for key in \
-    9554F04D7259F04124DE6B476D5A82AC7E37093B \
+    4ED778F539E3634C779C87C6D7062848A1AB005C \
+    B9E2F5981AA6E0CD28160D9FF13993A75599653C \
     94AE36675C464D64BAFA68DD7434390BDBE9B9C5 \
-    FD3A5288F042B6850C66B31F09FE44734EB7990E \
-    71DCFD284A79C3B38668286BC97EC7A07EDE3FC1 \
-    DD8F2338BAE7501E3DD5AC78C273792F7D83545D \
     B9AE9905FFD7803F25714661B63B535A4C206CA9 \
+    77984A986EBC2AA786BC0F66B01FBB92821C587A \
+    71DCFD284A79C3B38668286BC97EC7A07EDE3FC1 \
+    FD3A5288F042B6850C66B31F09FE44734EB7990E \
+    8FCCA13FEF1D0C2E91008E09770F7A9A5AE15600 \
     C4F0DFFF4E8C1A8236409D08E73BC641CC11F4C8 \
-    56730D5401028683275BD23C23EFEFE93C4CFFFE \
+    DD8F2338BAE7501E3DD5AC78C273792F7D83545D \
+    A48C2BEE680E841632CD4E44F07496B3EB3C1762 \
   ; do \
-    gpg --keyserver pool.sks-keyservers.net --recv-keys "$key" || \
-    gpg --keyserver hkp://ha.pool.sks-keyservers.net:80 --recv-keys "$key" || \
-    gpg --keyserver hkp://pgp.mit.edu:80 --recv-keys "$key" || \
-    gpg --keyserver hkp://keyserver.pgp.com:80 --recv-keys "$key" ; \
+    gpg --batch --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-keys "$key" || \
+    gpg --batch --keyserver hkp://ipv4.pool.sks-keyservers.net --recv-keys "$key" || \
+    gpg --batch --keyserver hkp://pgp.mit.edu:80 --recv-keys "$key" ; \
   done
 
 ENV NPM_CONFIG_LOGLEVEL info

--- a/2.3/Dockerfile
+++ b/2.3/Dockerfile
@@ -79,7 +79,7 @@ RUN gem install foreman \
   uglifier:2.1.1 \
   uglifier:3.0.2 \
   will_paginate:3.0.4 \
-  --no-ri --no-rdoc --verbose
+  --no-document --verbose
 
 # App Support tools
 RUN mkdir -p /app_support/geocoder \

--- a/2.4/Dockerfile
+++ b/2.4/Dockerfile
@@ -1,0 +1,73 @@
+FROM ruby:2.4-stretch
+
+# Install System libraries
+RUN apt-get update && apt-get install -y \
+    git \
+    imagemagick \
+    nginx \
+    supervisor \
+    awscli \
+  && rm -rf /var/lib/apt/lists/*
+
+# gpg keys listed at https://github.com/nodejs/node#release-keys
+RUN set -ex \
+  && for key in \
+    4ED778F539E3634C779C87C6D7062848A1AB005C \
+    B9E2F5981AA6E0CD28160D9FF13993A75599653C \
+    94AE36675C464D64BAFA68DD7434390BDBE9B9C5 \
+    B9AE9905FFD7803F25714661B63B535A4C206CA9 \
+    77984A986EBC2AA786BC0F66B01FBB92821C587A \
+    71DCFD284A79C3B38668286BC97EC7A07EDE3FC1 \
+    FD3A5288F042B6850C66B31F09FE44734EB7990E \
+    8FCCA13FEF1D0C2E91008E09770F7A9A5AE15600 \
+    C4F0DFFF4E8C1A8236409D08E73BC641CC11F4C8 \
+    DD8F2338BAE7501E3DD5AC78C273792F7D83545D \
+    A48C2BEE680E841632CD4E44F07496B3EB3C1762 \
+  ; do \
+    gpg --batch --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-keys "$key" || \
+    gpg --batch --keyserver hkp://ipv4.pool.sks-keyservers.net --recv-keys "$key" || \
+    gpg --batch --keyserver hkp://pgp.mit.edu:80 --recv-keys "$key" ; \
+  done
+
+ENV NPM_CONFIG_LOGLEVEL info
+ENV NODE_VERSION 10.15.3
+
+RUN curl -SLO "https://nodejs.org/dist/v$NODE_VERSION/node-v$NODE_VERSION-linux-x64.tar.xz" \
+  && curl -SLO "https://nodejs.org/dist/v$NODE_VERSION/SHASUMS256.txt.asc" \
+  && gpg --batch --decrypt --output SHASUMS256.txt SHASUMS256.txt.asc \
+  && grep " node-v$NODE_VERSION-linux-x64.tar.xz\$" SHASUMS256.txt | sha256sum -c - \
+  && tar -xJf "node-v$NODE_VERSION-linux-x64.tar.xz" -C /usr/local --strip-components=1 \
+  && rm "node-v$NODE_VERSION-linux-x64.tar.xz" SHASUMS256.txt.asc SHASUMS256.txt \
+  && ln -s /usr/local/bin/node /usr/local/bin/nodejs
+
+# Install foreman
+RUN gem install foreman --no-document
+
+# App Support tools
+RUN mkdir -p /app_support/geocoder \
+  && touch /app_support/geocoder/geodb.mmdb \
+  && curl -s "http://geolite.maxmind.com/download/geoip/database/GeoLite2-City.mmdb.gz" | gunzip -c > /app_support/geocoder/geodb.mmdb \
+  && chown -R www-data:www-data /app_support
+
+# Setup
+RUN mkdir -p /app /var/log/app \
+  && rm -f /etc/nginx/sites-enabled/* \
+  && chown -R www-data:www-data /app /var/log/app
+
+# Configuration
+COPY shared/nginx.conf /etc/nginx/
+COPY shared/app.conf /etc/nginx/sites-enabled/
+COPY shared/supervisord.conf /etc/supervisor/
+
+# Expose 80
+EXPOSE 80
+
+# Healthcheck
+COPY shared/healthcheck.sh /usr/local/bin/
+HEALTHCHECK --timeout=5s CMD bash /usr/local/bin/healthcheck.sh
+
+# Entrypoint command
+COPY shared/docker-entrypoint.sh /usr/local/bin/
+RUN chmod +x /usr/local/bin/docker-entrypoint.sh
+ENTRYPOINT ["/usr/local/bin/docker-entrypoint.sh"]
+CMD [ "/usr/bin/supervisord", "-c", "/etc/supervisor/supervisord.conf" ]

--- a/2.5/Dockerfile
+++ b/2.5/Dockerfile
@@ -12,19 +12,21 @@ RUN apt-get update && apt-get install -y \
 # gpg keys listed at https://github.com/nodejs/node#release-team
 RUN set -ex \
   && for key in \
-    9554F04D7259F04124DE6B476D5A82AC7E37093B \
+    4ED778F539E3634C779C87C6D7062848A1AB005C \
+    B9E2F5981AA6E0CD28160D9FF13993A75599653C \
     94AE36675C464D64BAFA68DD7434390BDBE9B9C5 \
-    FD3A5288F042B6850C66B31F09FE44734EB7990E \
-    71DCFD284A79C3B38668286BC97EC7A07EDE3FC1 \
-    DD8F2338BAE7501E3DD5AC78C273792F7D83545D \
     B9AE9905FFD7803F25714661B63B535A4C206CA9 \
+    77984A986EBC2AA786BC0F66B01FBB92821C587A \
+    71DCFD284A79C3B38668286BC97EC7A07EDE3FC1 \
+    FD3A5288F042B6850C66B31F09FE44734EB7990E \
+    8FCCA13FEF1D0C2E91008E09770F7A9A5AE15600 \
     C4F0DFFF4E8C1A8236409D08E73BC641CC11F4C8 \
-    56730D5401028683275BD23C23EFEFE93C4CFFFE \
+    DD8F2338BAE7501E3DD5AC78C273792F7D83545D \
+    A48C2BEE680E841632CD4E44F07496B3EB3C1762 \
   ; do \
-    gpg --keyserver pool.sks-keyservers.net --recv-keys "$key" || \
-    gpg --keyserver hkp://ha.pool.sks-keyservers.net:80 --recv-keys "$key" || \
-    gpg --keyserver hkp://pgp.mit.edu:80 --recv-keys "$key" || \
-    gpg --keyserver hkp://keyserver.pgp.com:80 --recv-keys "$key" ; \
+    gpg --batch --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-keys "$key" || \
+    gpg --batch --keyserver hkp://ipv4.pool.sks-keyservers.net --recv-keys "$key" || \
+    gpg --batch --keyserver hkp://pgp.mit.edu:80 --recv-keys "$key" ; \
   done
 
 ENV NPM_CONFIG_LOGLEVEL info

--- a/2.5/Dockerfile
+++ b/2.5/Dockerfile
@@ -41,7 +41,7 @@ RUN curl -SLO "https://nodejs.org/dist/v$NODE_VERSION/node-v$NODE_VERSION-linux-
   && ln -s /usr/local/bin/node /usr/local/bin/nodejs
 
 # Install foreman
-RUN gem install foreman --no-ri --no-rdoc
+RUN gem install foreman --no-document
 
 # App Support tools
 RUN mkdir -p /app_support/geocoder \

--- a/2.6/Dockerfile
+++ b/2.6/Dockerfile
@@ -9,22 +9,24 @@ RUN apt-get update && apt-get install -y \
     awscli \
   && rm -rf /var/lib/apt/lists/*
 
-# gpg keys listed at https://github.com/nodejs/node#release-team
+# gpg keys listed at https://github.com/nodejs/node#release-keys
 RUN set -ex \
   && for key in \
-    9554F04D7259F04124DE6B476D5A82AC7E37093B \
+    4ED778F539E3634C779C87C6D7062848A1AB005C \
+    B9E2F5981AA6E0CD28160D9FF13993A75599653C \
     94AE36675C464D64BAFA68DD7434390BDBE9B9C5 \
-    FD3A5288F042B6850C66B31F09FE44734EB7990E \
-    71DCFD284A79C3B38668286BC97EC7A07EDE3FC1 \
-    DD8F2338BAE7501E3DD5AC78C273792F7D83545D \
     B9AE9905FFD7803F25714661B63B535A4C206CA9 \
+    77984A986EBC2AA786BC0F66B01FBB92821C587A \
+    71DCFD284A79C3B38668286BC97EC7A07EDE3FC1 \
+    FD3A5288F042B6850C66B31F09FE44734EB7990E \
+    8FCCA13FEF1D0C2E91008E09770F7A9A5AE15600 \
     C4F0DFFF4E8C1A8236409D08E73BC641CC11F4C8 \
-    56730D5401028683275BD23C23EFEFE93C4CFFFE \
+    DD8F2338BAE7501E3DD5AC78C273792F7D83545D \
+    A48C2BEE680E841632CD4E44F07496B3EB3C1762 \
   ; do \
-    gpg --keyserver pool.sks-keyservers.net --recv-keys "$key" || \
-    gpg --keyserver hkp://ha.pool.sks-keyservers.net:80 --recv-keys "$key" || \
-    gpg --keyserver hkp://pgp.mit.edu:80 --recv-keys "$key" || \
-    gpg --keyserver hkp://keyserver.pgp.com:80 --recv-keys "$key" ; \
+    gpg --batch --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-keys "$key" || \
+    gpg --batch --keyserver hkp://ipv4.pool.sks-keyservers.net --recv-keys "$key" || \
+    gpg --batch --keyserver hkp://pgp.mit.edu:80 --recv-keys "$key" ; \
   done
 
 ENV NPM_CONFIG_LOGLEVEL info

--- a/2.6/Dockerfile
+++ b/2.6/Dockerfile
@@ -41,7 +41,7 @@ RUN curl -SLO "https://nodejs.org/dist/v$NODE_VERSION/node-v$NODE_VERSION-linux-
   && ln -s /usr/local/bin/node /usr/local/bin/nodejs
 
 # Install foreman
-RUN gem install foreman --no-ri --no-rdoc
+RUN gem install foreman --no-document
 
 # App Support tools
 RUN mkdir -p /app_support/geocoder \

--- a/2.6/Dockerfile
+++ b/2.6/Dockerfile
@@ -1,0 +1,71 @@
+FROM ruby:2.6-stretch
+
+# Install System libraries
+RUN apt-get update && apt-get install -y \
+    git \
+    imagemagick \
+    nginx \
+    supervisor \
+    awscli \
+  && rm -rf /var/lib/apt/lists/*
+
+# gpg keys listed at https://github.com/nodejs/node#release-team
+RUN set -ex \
+  && for key in \
+    9554F04D7259F04124DE6B476D5A82AC7E37093B \
+    94AE36675C464D64BAFA68DD7434390BDBE9B9C5 \
+    FD3A5288F042B6850C66B31F09FE44734EB7990E \
+    71DCFD284A79C3B38668286BC97EC7A07EDE3FC1 \
+    DD8F2338BAE7501E3DD5AC78C273792F7D83545D \
+    B9AE9905FFD7803F25714661B63B535A4C206CA9 \
+    C4F0DFFF4E8C1A8236409D08E73BC641CC11F4C8 \
+    56730D5401028683275BD23C23EFEFE93C4CFFFE \
+  ; do \
+    gpg --keyserver pool.sks-keyservers.net --recv-keys "$key" || \
+    gpg --keyserver hkp://ha.pool.sks-keyservers.net:80 --recv-keys "$key" || \
+    gpg --keyserver hkp://pgp.mit.edu:80 --recv-keys "$key" || \
+    gpg --keyserver hkp://keyserver.pgp.com:80 --recv-keys "$key" ; \
+  done
+
+ENV NPM_CONFIG_LOGLEVEL info
+ENV NODE_VERSION 10.15.3
+
+RUN curl -SLO "https://nodejs.org/dist/v$NODE_VERSION/node-v$NODE_VERSION-linux-x64.tar.xz" \
+  && curl -SLO "https://nodejs.org/dist/v$NODE_VERSION/SHASUMS256.txt.asc" \
+  && gpg --batch --decrypt --output SHASUMS256.txt SHASUMS256.txt.asc \
+  && grep " node-v$NODE_VERSION-linux-x64.tar.xz\$" SHASUMS256.txt | sha256sum -c - \
+  && tar -xJf "node-v$NODE_VERSION-linux-x64.tar.xz" -C /usr/local --strip-components=1 \
+  && rm "node-v$NODE_VERSION-linux-x64.tar.xz" SHASUMS256.txt.asc SHASUMS256.txt \
+  && ln -s /usr/local/bin/node /usr/local/bin/nodejs
+
+# Install foreman
+RUN gem install foreman --no-ri --no-rdoc
+
+# App Support tools
+RUN mkdir -p /app_support/geocoder \
+  && touch /app_support/geocoder/geodb.mmdb \
+  && curl -s "http://geolite.maxmind.com/download/geoip/database/GeoLite2-City.mmdb.gz" | gunzip -c > /app_support/geocoder/geodb.mmdb \
+  && chown -R www-data:www-data /app_support
+
+# Setup
+RUN mkdir -p /app /var/log/app \
+  && rm -f /etc/nginx/sites-enabled/* \
+  && chown -R www-data:www-data /app /var/log/app
+
+# Configuration
+COPY shared/nginx.conf /etc/nginx/
+COPY shared/app.conf /etc/nginx/sites-enabled/
+COPY shared/supervisord.conf /etc/supervisor/
+
+# Expose 80
+EXPOSE 80
+
+# Healthcheck
+COPY shared/healthcheck.sh /usr/local/bin/
+HEALTHCHECK --timeout=5s CMD bash /usr/local/bin/healthcheck.sh
+
+# Entrypoint command
+COPY shared/docker-entrypoint.sh /usr/local/bin/
+RUN chmod +x /usr/local/bin/docker-entrypoint.sh
+ENTRYPOINT ["/usr/local/bin/docker-entrypoint.sh"]
+CMD [ "/usr/bin/supervisord", "-c", "/etc/supervisor/supervisord.conf" ]


### PR DESCRIPTION
Add ruby 2.4 & 2.6 image (based on stretch) with node 10 (other images are still using node 6)

Updated docker build rules for 2.6:
<img width="1075" alt="Screen Shot 2019-03-21 at 18 36 57" src="https://user-images.githubusercontent.com/19894/54738446-6df91300-4c08-11e9-8dc4-7c3d99230417.png">

See #34 for when we added 2.5

Edit: also updated for 2.4