### PR TITLE
Use stretch for 2.3

### DIFF
--- a/2.3/Dockerfile
+++ b/2.3/Dockerfile
@@ -1,4 +1,4 @@
-FROM ruby:2.3-jessie
+FROM ruby:2.3-stretch
 
 # Install System libraries
 RUN apt-get update && apt-get install -y \


### PR DESCRIPTION
Use 2.3-stretch as the base image to be consistent with the other ruby
versions.
We're also using stretch to run our tests on CirleCI.

I also need stretch to get a newer version of `awscli`.