### PR TITLE
Port v1.0 update

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ before_install:
 script:
   # Build docker image
   - cd 2.3/
-  - docker build -t maestrano/web-ruby:travis . > /dev/null 2>&1
+  - docker build -t maestrano/web-ruby:travis .
 
   #=======================================
   # Test with minimal parameters

--- a/2.3/Dockerfile
+++ b/2.3/Dockerfile
@@ -92,7 +92,7 @@ RUN gem install foreman \
   uglifier:2.1.1 \
   uglifier:3.0.2 \
   will_paginate:3.0.4 \
-  --no-ri --no-rdoc --verbose
+  --no-document --verbose
 
 # Install python 3.5.5 as a stand alone library
 RUN curl https://www.python.org/ftp/python/3.5.5/Python-3.5.5.tgz | tar xzf - -C /tmp

--- a/2.3/Dockerfile
+++ b/2.3/Dockerfile
@@ -1,4 +1,4 @@
-FROM ruby:2.3-jessie
+FROM ruby:2.3-stretch
 
 ENV MYSQL_APT_VERSION 0.8.9-1
 ENV DEBIAN_FRONTEND noninteractive

--- a/2.3/Dockerfile
+++ b/2.3/Dockerfile
@@ -1,6 +1,5 @@
 FROM ruby:2.3-stretch
 
-ENV MYSQL_APT_VERSION 0.8.9-1
 ENV DEBIAN_FRONTEND noninteractive
 
 # Install System libraries
@@ -12,16 +11,6 @@ RUN apt-get update \
     nginx \
     supervisor \
     awscli \
-    lsb-release \
-    debconf-utils
-
-# Use official MySQL repository
-RUN wget http://dev.mysql.com/get/mysql-apt-config_${MYSQL_APT_VERSION}_all.deb
-RUN echo "mysql-apt-config mysql-apt-config/select-tools select Enabled" | debconf-set-selections
-RUN dpkg -i mysql-apt-config_${MYSQL_APT_VERSION}_all.deb \
-  && rm -f mysql-apt-config_${MYSQL_APT_VERSION}_all.deb \
-  && apt-get update \
-  && apt-get install -y libmysqlclient-dev \
   && rm -rf /var/lib/apt/lists/*
 
 # gpg keys listed at https://github.com/nodejs/node#release-team

--- a/2.3/Dockerfile
+++ b/2.3/Dockerfile
@@ -11,6 +11,7 @@ RUN apt-get update \
     nginx \
     supervisor \
     awscli \
+    python3-dev \
   && rm -rf /var/lib/apt/lists/*
 
 # gpg keys listed at https://github.com/nodejs/node#release-team
@@ -83,18 +84,8 @@ RUN gem install foreman \
   will_paginate:3.0.4 \
   --no-document --verbose
 
-# Install python 3.5.5 as a stand alone library
-RUN curl https://www.python.org/ftp/python/3.5.5/Python-3.5.5.tgz | tar xzf - -C /tmp
-RUN cd /tmp/Python-3.5.5 \
-	&& ./configure --prefix=/opt/python \
-	&& make \
-	&& make install
-
-# Add python3.5 to PATH
-ENV PATH="${PATH}:/opt/python/bin"
-
-# Upgrade pip and wheel
-RUN pip3 install pip==10.0.1 wheel==0.31.1
+# Install pip3
+RUN wget https://bootstrap.pypa.io/get-pip.py && python3 get-pip.py
 
 # App Support tools
 RUN mkdir -p /app_support/geocoder \

--- a/2.3/Dockerfile
+++ b/2.3/Dockerfile
@@ -36,6 +36,7 @@ RUN set -ex \
     C4F0DFFF4E8C1A8236409D08E73BC641CC11F4C8 \
     56730D5401028683275BD23C23EFEFE93C4CFFFE \
   ; do \
+    gpg --keyserver pool.sks-keyservers.net --recv-keys "$key" || \
     gpg --keyserver hkp://ha.pool.sks-keyservers.net:80 --recv-keys "$key" || \
     gpg --keyserver hkp://pgp.mit.edu:80 --recv-keys "$key" || \
     gpg --keyserver hkp://keyserver.pgp.com:80 --recv-keys "$key" ; \

--- a/2.3/Dockerfile
+++ b/2.3/Dockerfile
@@ -27,7 +27,7 @@ RUN set -ex \
   done
 
 ENV NPM_CONFIG_LOGLEVEL info
-ENV NODE_VERSION 6.12.0
+ENV NODE_VERSION 6.14.4
 
 RUN curl -SLO "https://nodejs.org/dist/v$NODE_VERSION/node-v$NODE_VERSION-linux-x64.tar.xz" \
   && curl -SLO "https://nodejs.org/dist/v$NODE_VERSION/SHASUMS256.txt.asc" \

--- a/2.3/docker-entrypoint.sh
+++ b/2.3/docker-entrypoint.sh
@@ -30,6 +30,8 @@ elif [ -n "$S3_URI" ]; then
   if [ -z "$S3_SECRET_ACCESS_KEY" ]; then
     opts="--no-sign-request"
   fi
+  # Setting Signature Version 4 for S3 Request Authentication
+  aws configure set s3.signature_version s3v4
   AWS_ACCESS_KEY_ID=$S3_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY=$S3_SECRET_ACCESS_KEY AWS_DEFAULT_REGION=$S3_REGION aws s3 cp $opts $S3_URI ./
   archive_file=${S3_URI##*/}
   echo "Unzipping $archive_file"


### PR DESCRIPTION
The 2.0 branch is only used by the reconciliation engine and needed to be updated to support KMS encrypted S3 buckets (see #37). 
I took the opportunity to also port some updates done in the 1.0 branch (mainly to fix the docker build)

Main changes:
- [MARLIN-882] Enable S3 Signature Version 4 for aws #37
- Bump node version #33
- Use stretch for 2.3

Since we're now using stretch, I was able to make the following changes:
- Remove external MySQL repository
- Use packaged python3.5 and install pip3


[MARLIN-882]: https://maestrano.atlassian.net/browse/MARLIN-882